### PR TITLE
Remove Python builtins token from the grammar

### DIFF
--- a/generate_grammar.py
+++ b/generate_grammar.py
@@ -22,15 +22,10 @@ def generate_grammar():
         "-Dlanguage=Python3",
         shell=True
     )
-
-    # todo: Enable this check
-    #  This is currently failing as grammar use symbol names that conflict with Python builtins
-    #  They can probably be renamed
-    #
-    # if generation_failed:
-    #     raise EnvironmentError(
-    #         f"An unexpected error occured while generating grammar file (code {generation_failed})\n"
-    #     )
+    if generation_failed:
+        raise EnvironmentError(
+            f"An unexpected error occured while generating grammar file (code {generation_failed})\n"
+        )
 
 
 if __name__ == '__main__':

--- a/src/sqlparser/grammar/SqlBase.g4
+++ b/src/sqlparser/grammar/SqlBase.g4
@@ -787,7 +787,7 @@ primaryExpression
     | STRUCT '(' (argument+=namedExpression (',' argument+=namedExpression)*)? ')'             #struct
     | FIRST '(' expression (IGNORE NULLS)? ')'                                                 #first
     | LAST '(' expression (IGNORE NULLS)? ')'                                                  #last
-    | POSITION '(' substr=valueExpression IN str=valueExpression ')'                           #position
+    | POSITION '(' substr=valueExpression IN superstr=valueExpression ')'                           #position
     | constant                                                                                 #constantDefault
     | ASTERISK                                                                                 #star
     | qualifiedName '.' ASTERISK                                                               #star
@@ -802,11 +802,11 @@ primaryExpression
     | base=primaryExpression '.' fieldName=identifier                                          #dereference
     | '(' expression ')'                                                                       #parenthesizedExpression
     | EXTRACT '(' field=identifier FROM source=valueExpression ')'                             #extract
-    | (SUBSTR | SUBSTRING) '(' str=valueExpression (FROM | ',') pos=valueExpression
-      ((FOR | ',') len=valueExpression)? ')'                                                   #substring
+    | (SUBSTR | SUBSTRING) '(' superstr=valueExpression (FROM | ',') pos=valueExpression
+      ((FOR | ',') length=valueExpression)? ')'                                                   #substring
     | TRIM '(' trimOption=(BOTH | LEADING | TRAILING)? (trimStr=valueExpression)?
        FROM srcStr=valueExpression ')'                                                         #trim
-    | OVERLAY '(' input=valueExpression PLACING replace=valueExpression
+    | OVERLAY '(' initial_value=valueExpression PLACING replace=valueExpression
       FROM position=valueExpression (FOR length=valueExpression)? ')'                          #overlay
     ;
 
@@ -875,9 +875,9 @@ colPosition
     ;
 
 dataType
-    : complex=ARRAY '<' dataType '>'                            #complexDataType
-    | complex=MAP '<' dataType ',' dataType '>'                 #complexDataType
-    | complex=STRUCT ('<' complexColTypeList? '>' | NEQ)        #complexDataType
+    : complexDefinition=ARRAY '<' dataType '>'                            #complexDataType
+    | complexDefinition=MAP '<' dataType ',' dataType '>'                 #complexDataType
+    | complexDefinition=STRUCT ('<' complexColTypeList? '>' | NEQ)        #complexDataType
     | identifier ('(' INTEGER_VALUE (',' INTEGER_VALUE)* ')')?  #primitiveDataType
     ;
 


### PR DESCRIPTION
SqlBase.g4 defines tokens suchs as len, str, complex and input in some context which conflict with Python builtins.

This was bad for two reasons:

    When manipulating this tokens,there can be conflicts between the grammar and Python
    Antlr always returned a non-zero exit code when generating the grammar, preventing checks on it
